### PR TITLE
remove engines

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,9 +23,6 @@
 	"repository": "derhuerst/email-providers",
 	"bugs": "https://github.com/derhuerst/email-providers/issues",
 	"license": "ISC",
-	"engines": {
-		"node": ">=18"
-	},
 	"devDependencies": {
 		"node-fetch": "^3.0.0",
 		"lodash.uniq": "^4.5",


### PR DESCRIPTION
for such a simple package requiring node 18 is overkill. You can consume this with a potato, you don't need latest and greatest nodejs